### PR TITLE
Add simple e‑learning platform

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,136 +3,247 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Hofstede Cultural Assessment</title>
+  <title>ER Excellence e-Learning</title>
   <style>
-    body { font-family: Arial, sans-serif; margin: 0; padding: 0 10px; }
-    #container { max-width: 600px; margin: auto; }
-    h1 { font-size: 1.5em; text-align: center; }
-    .question { display: none; margin-top: 20px; }
-    .question.active { display: block; }
-    label { display: block; padding: 8px; border: 1px solid #ccc; border-radius: 4px; margin: 8px 0; }
-    input[type="radio"] { margin-right: 10px; }
-    .nav { margin-top: 20px; display: flex; justify-content: space-between; }
-    button { padding: 10px 20px; font-size: 1em; border: none; border-radius: 4px; background:#007BFF; color:#fff; }
-    #submitBtn { width:100%; margin-top:20px; background:#28a745; }
-    #result { margin-top: 20px; }
+    body {
+      margin: 0;
+      font-family: Arial, sans-serif;
+      display: flex;
+      min-height: 100vh;
+    }
+    #sidebar {
+      width: 220px;
+      background: #f4f4f4;
+      border-right: 1px solid #ddd;
+      padding: 10px;
+      box-sizing: border-box;
+      overflow-y: auto;
+    }
+    #content {
+      flex: 1;
+      padding: 20px;
+    }
+    h2 {
+      margin-top: 0;
+    }
+    .module, .lesson {
+      cursor: pointer;
+      margin: 5px 0;
+    }
+    .module-title {
+      font-weight: bold;
+    }
+    .hidden {
+      display: none;
+    }
+    .lesson.completed {
+      color: green;
+    }
+    button {
+      padding: 8px 16px;
+      margin-top: 20px;
+    }
+    @media (max-width: 600px) {
+      #sidebar {
+        width: 100%;
+        border-right: none;
+        border-bottom: 1px solid #ddd;
+      }
+    }
   </style>
 </head>
 <body>
-<div id="container">
-<h1>Hofstede Cultural Assessment</h1>
-<form id="quizForm">
-  <div id="questions"></div>
-  <div class="nav">
-    <button type="button" id="backBtn">Back</button>
-    <button type="button" id="nextBtn">Next</button>
-  </div>
-  <button type="button" id="submitBtn" style="display:none;">Submit</button>
-</form>
-<div id="result"></div>
-</div>
-<script>
-const questionsData = [
-  {dim:'PDI', text:'It is acceptable that power is distributed unequally in organizations.'},
-  {dim:'PDI', text:'I feel comfortable with clear hierarchical structures.'},
-  {dim:'PDI', text:'Employees should not question the decisions of their superiors.'},
-  {dim:'PDI', text:'Decision-making should rest with senior managers.'},
-  {dim:'IDV', text:'Personal success is more important than group loyalty.'},
-  {dim:'IDV', text:'I prefer working independently rather than in teams.'},
-  {dim:'IDV', text:'Individual rights should take precedence over group interests.'},
-  {dim:'IDV', text:'Being different from others is acceptable.'},
-  {dim:'MAS', text:'Achievement is more important than quality of life.'},
-  {dim:'MAS', text:'Competition leads to the best results.'},
-  {dim:'MAS', text:'Assertiveness is valued over modesty.'},
-  {dim:'MAS', text:'Gender roles should be clearly distinguished.'},
-  {dim:'UAI', text:'Rules and procedures help reduce uncertainty.'},
-  {dim:'UAI', text:'Ambiguous situations make me uncomfortable.'},
-  {dim:'UAI', text:'I prefer structured tasks over unstructured ones.'},
-  {dim:'UAI', text:'Planning ahead is important to me.'},
-  {dim:'LTO', text:'I focus on long-term goals rather than immediate results.'},
-  {dim:'LTO', text:'Tradition is less important than preparing for the future.'},
-  {dim:'LTO', text:'Persistence and thrift are virtues.'},
-  {dim:'LTO', text:'I am willing to adapt plans to new circumstances.'},
-  {dim:'IND', text:'Leisure time is essential to me.'},
-  {dim:'IND', text:'People should be free to gratify their desires.'},
-  {dim:'IND', text:'I openly express my feelings.'},
-  {dim:'IND', text:'Strict social norms can hinder personal enjoyment.'}
-];
+  <div id="sidebar"></div>
+  <main id="content">
+    <h1>Welcome</h1>
+    <p>Select a course to begin.</p>
+  </main>
+  <script>
+  const courses = [
+    {
+      id: 'er',
+      title: 'ER Excellence Assessor Training',
+      modules: [
+        {
+          title: 'Module 1: Introduction',
+          lessons: [
+            { type: 'text', content: 'Welcome to the ER Excellence Assessor Training course. Use the next button to proceed through each lesson.' }
+          ]
+        },
+        {
+          title: 'Module 2: ER Framework',
+          lessons: [
+            { type: 'text', content: 'Lesson 1: Overview of the ER Framework.' },
+            { type: 'text', content: 'Lesson 2: Key principles of effective employee relations.' },
+            { type: 'text', content: 'Lesson 3: Communication strategies.' },
+            { type: 'text', content: 'Lesson 4: Conflict resolution.' },
+            { type: 'text', content: 'Lesson 5: Documentation requirements.' },
+            { type: 'text', content: 'Lesson 6: Metrics and reporting.' },
+            { type: 'text', content: 'Lesson 7: Continuous improvement.' }
+          ]
+        },
+        {
+          title: 'Module 3: Quiz',
+          lessons: [
+            { type: 'quiz', question: 'What does ER stand for?', options: ['Employee Relations','Employer Responsibilities','Efficiency Rating'], correct: 0 },
+            { type: 'quiz', question: 'Which lesson covers communication strategies?', options: ['Lesson 3','Lesson 5','Lesson 7'], correct: 0 },
+            { type: 'quiz', question: 'True or False: Metrics are part of the framework.', options: ['True','False'], correct: 0 }
+          ]
+        },
+        {
+          title: 'Module 4: Case Study',
+          lessons: [
+            { type: 'case', question: 'In 50 words or more, describe how you would address a workplace conflict.' }
+          ]
+        },
+        {
+          title: 'Module 5: Certification Summary',
+          lessons: [
+            { type: 'summary' }
+          ]
+        }
+      ]
+    }
+  ];
 
-// shuffle questions
-const shuffled = questionsData.sort(() => Math.random() - 0.5);
-const questionsDiv = document.getElementById('questions');
-shuffled.forEach((q,i) => {
-  const div = document.createElement('div');
-  div.className = 'question';
-  div.id = 'q'+i;
-  div.innerHTML = `<p>${q.text}</p>` + [1,2,3,4,5].map(n => `<label><input type="radio" name="q${i}" value="${n}" required> ${n}</label>`).join('');
-  questionsDiv.appendChild(div);
-});
+  const progress = JSON.parse(localStorage.getItem('er_progress') || '{}');
+  if (!progress.completed) progress.completed = {};
+  if (!progress.quizScore) progress.quizScore = 0;
+  if (!progress.caseScore) progress.caseScore = 0;
 
-let current = 0;
-const total = shuffled.length;
-const backBtn = document.getElementById('backBtn');
-const nextBtn = document.getElementById('nextBtn');
-const submitBtn = document.getElementById('submitBtn');
+  const sidebar = document.getElementById('sidebar');
+  const content = document.getElementById('content');
+  let currentCourse = 0;
+  let currentModule = 0;
+  let currentLesson = 0;
+  let quizTempScore = 0;
 
-function showQuestion(idx){
-  document.querySelectorAll('.question').forEach(q => q.classList.remove('active'));
-  document.getElementById('q'+idx).classList.add('active');
-  backBtn.style.display = idx === 0 ? 'none' : 'inline-block';
-  nextBtn.style.display = idx === total-1 ? 'none' : 'inline-block';
-  submitBtn.style.display = idx === total-1 ? 'inline-block' : 'none';
-}
-showQuestion(current);
-
-nextBtn.addEventListener('click', ()=>{
-  const checked = document.querySelector('#q'+current+' input:checked');
-  if(!checked){
-    alert('Please select a response.');
-    return;
+  function saveProgress() {
+    localStorage.setItem('er_progress', JSON.stringify(progress));
   }
-  if(current < total-1){
-    current++;
-    showQuestion(current);
-  }
-});
 
-backBtn.addEventListener('click', ()=>{
-  if(current>0){
-    current--;
-    showQuestion(current);
-  }
-});
+  function renderSidebar() {
+    sidebar.innerHTML = '';
+    courses.forEach((course, cIndex) => {
+      const cDiv = document.createElement('div');
+      cDiv.textContent = course.title;
+      cDiv.className = 'course-title';
+      sidebar.appendChild(cDiv);
 
-submitBtn.addEventListener('click', ()=>{
-  const scores = {PDI:0, IDV:0, MAS:0, UAI:0, LTO:0, IND:0};
-  shuffled.forEach((q,i)=>{
-    const val = parseInt(document.querySelector(`input[name="q${i}"]:checked`).value);
-    scores[q.dim]+=val;
-  });
-  const interpret = {
-    PDI:'A high score indicates comfort with hierarchy; a low score suggests preference for equality.',
-    IDV:'High values reflect individualism; low values show collectivism.',
-    MAS:'High scores emphasize competition and achievement; low scores value caring and quality of life.',
-    UAI:'High scores show discomfort with uncertainty; low scores tolerate ambiguity.',
-    LTO:'High scores reveal long-term pragmatism; low scores focus on short-term and tradition.',
-    IND:'High scores represent indulgence; low scores indicate restraint and strict norms.'
-  };
-  const names = {
-    PDI:'Power Distance Index',
-    IDV:'Individualism vs. Collectivism',
-    MAS:'Masculinity vs. Femininity',
-    UAI:'Uncertainty Avoidance Index',
-    LTO:'Long-Term Orientation',
-    IND:'Indulgence vs. Restraint'
-  };
-  let html = '<h2>Your Cultural Profile</h2>';
-  Object.keys(scores).forEach(dim=>{
-    html += `<p><strong>${dim} - ${names[dim]}</strong>: ${scores[dim]} / 20<br>${interpret[dim]}</p>`;
-  });
-  document.getElementById('quizForm').style.display='none';
-  document.getElementById('result').innerHTML=html;
-});
-</script>
+      course.modules.forEach((mod, mIndex) => {
+        const mDiv = document.createElement('div');
+        mDiv.textContent = mod.title;
+        mDiv.className = 'module';
+        if (progress.completed[mIndex]) mDiv.classList.add('completed');
+        mDiv.onclick = () => openModule(mIndex);
+        sidebar.appendChild(mDiv);
+      });
+    });
+  }
+
+  function openModule(mIndex) {
+    currentModule = mIndex;
+    currentLesson = 0;
+    loadLesson();
+  }
+
+  function nextLesson() {
+    currentLesson++;
+    loadLesson();
+  }
+
+  function loadLesson() {
+    const module = courses[currentCourse].modules[currentModule];
+    if (currentLesson >= module.lessons.length) {
+      progress.completed[currentModule] = true;
+      saveProgress();
+      renderSidebar();
+      if (currentModule + 1 < courses[currentCourse].modules.length) {
+        currentModule++;
+        currentLesson = 0;
+        loadLesson();
+      } else {
+        showSummary();
+      }
+      return;
+    }
+
+    const lesson = module.lessons[currentLesson];
+    content.innerHTML = `<h2>${module.title}</h2>`;
+    if (lesson.type === 'text') {
+      const p = document.createElement('p');
+      p.textContent = lesson.content;
+      content.appendChild(p);
+      const btn = document.createElement('button');
+      btn.textContent = 'Next';
+      btn.onclick = nextLesson;
+      content.appendChild(btn);
+    } else if (lesson.type === 'quiz') {
+      const q = document.createElement('p');
+      q.textContent = lesson.question;
+      content.appendChild(q);
+      lesson.options.forEach((opt, idx) => {
+        const label = document.createElement('label');
+        const radio = document.createElement('input');
+        radio.type = 'radio';
+        radio.name = 'q';
+        radio.value = idx;
+        label.appendChild(radio);
+        label.appendChild(document.createTextNode(opt));
+        content.appendChild(label);
+      });
+      const btn = document.createElement('button');
+      btn.textContent = 'Submit';
+      btn.onclick = () => {
+        const checked = content.querySelector('input[name="q"]:checked');
+        if (!checked) return;
+        if (parseInt(checked.value, 10) === lesson.correct) quizTempScore++;
+        nextLesson();
+      };
+      content.appendChild(btn);
+    } else if (lesson.type === 'case') {
+      const q = document.createElement('p');
+      q.textContent = lesson.question;
+      content.appendChild(q);
+      const textarea = document.createElement('textarea');
+      textarea.rows = 6;
+      textarea.style.width = '100%';
+      content.appendChild(textarea);
+      const btn = document.createElement('button');
+      btn.textContent = 'Submit';
+      btn.onclick = () => {
+        const words = textarea.value.trim().split(/\s+/).length;
+        if (words >= 50) progress.caseScore = 100; else progress.caseScore = Math.round((words/50)*100);
+        nextLesson();
+      };
+      content.appendChild(btn);
+    } else if (lesson.type === 'summary') {
+      showSummary();
+    }
+  }
+
+  function showSummary() {
+    progress.quizScore = quizTempScore;
+    saveProgress();
+    content.innerHTML = '<h2>Certification Summary</h2>';
+    const p = document.createElement('p');
+    p.textContent = `Quiz Score: ${progress.quizScore}/3`;
+    content.appendChild(p);
+    const p2 = document.createElement('p');
+    p2.textContent = `Case Study Score: ${progress.caseScore}%`;
+    content.appendChild(p2);
+    const completed = Object.keys(progress.completed).length === courses[currentCourse].modules.length - 1; // exclude summary
+    const pass = progress.quizScore >= 2 && progress.caseScore >= 70;
+    const status = document.createElement('p');
+    if (completed && pass) {
+      status.textContent = 'Status: Certified Assessor';
+    } else {
+      status.textContent = 'Status: Try Again';
+    }
+    content.appendChild(status);
+  }
+
+  renderSidebar();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace previous questionnaire with a small e-learning template
- support modules, quiz and case study
- store progress in localStorage and show certification status

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686f8d0cc7a483329b2feffbf90bd9e3