### PR TITLE
Add Executive Swipe Decision Accelerator (React frontend + Express + SQLite backend)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXT_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.env
+.env.local
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,66 +1,106 @@
-# Executive Swipe Decision Accelerator
+# Task Manager (Next.js + Supabase)
 
-A lightweight task-management web app focused on executive decision velocity. Tasks are reviewed one at a time using swipe gestures and keyboard shortcuts.
+Production-ready task manager built with Next.js App Router, Supabase Auth/Database, TypeScript, and Tailwind CSS.
 
-## Stack
-- **Frontend:** React (CDN + JSX via Babel)
-- **Backend:** Node.js + Express
-- **Database:** SQLite
-- **Auth:** Email/password + JWT
+## Features
 
-## Project structure
+- Email/password login with Supabase Auth
+- Redirect unauthenticated users to `/login` from dashboard session check
+- Task dashboard for authenticated users only
+- CRUD for tasks (create, inline edit, delete)
+- Status and priority updates
+- Filters by status and priority
+- Dark, mobile-friendly UI
 
-- `server.js` - Express server and REST API routes
-- `server/db.js` - SQLite schema + seed helpers
-- `scripts/seed.js` - Manual seed runner
-- `public/index.html` - Frontend shell
-- `public/app.jsx` - Swipe UI, filters, modal editing
-- `public/styles.css` - Mobile-first styles with RAG accents
+## Tech Stack
 
-## Features delivered
-- Swipe review mode with one-task-at-a-time cards
-  - Right: Keep active
-  - Left: Soft-delete (archive)
-  - Down: Move to MONITOR
-  - Up: Open comment/edit modal
-  - Tap: View full details
-- Filtering by horizon, country, theme, parent/sub-task scope
-- Parent container support with progress indicator (`x/y complete`)
-- Comment/edit panel to update responsibility, horizon, notes, RAG
-- Convert any task to parent container and add sub-tasks
-- Basic auth (register/login)
-- Decision velocity dashboard (reviewed today, keep/delete ratio, horizon distribution)
-- Keyboard shortcuts
-  - `→` Keep
-  - `←` Delete
-  - `↑` Comment/Edit
-  - `↓` Move to MONITOR
+- Next.js (App Router)
+- TypeScript
+- Tailwind CSS
+- Supabase (`@supabase/supabase-js`)
 
-## Setup
+## Project Structure
+
+```txt
+/app
+  /components
+    task-dashboard.tsx
+  /dashboard
+    page.tsx
+  /login
+    page.tsx
+  globals.css
+  layout.tsx
+  page.tsx
+/lib
+  supabaseClient.ts
+```
+
+## 1) Run locally
 
 ```bash
 npm install
-npm run seed
-npm start
+cp .env.example .env.local
+npm run dev
 ```
 
-Then open: `http://localhost:3000`
+Open http://localhost:3000
 
-## API overview
+## 2) Connect Supabase
 
-### Auth
-- `POST /api/auth/register`
-- `POST /api/auth/login`
+Create a Supabase project and set environment variables in `.env.local`:
 
-### Tasks
-- `GET /api/tasks?horizon=NOW&country=UK&theme=Operations&scope=parents&parent_id=<id>`
-- `GET /api/tasks/:id`
-- `POST /api/tasks`
-- `PATCH /api/tasks/:id`
-- `POST /api/tasks/:id/swipe` with `{ "action": "keep|delete|defer" }`
+```env
+NEXT_PUBLIC_SUPABASE_URL=...
+NEXT_PUBLIC_SUPABASE_ANON_KEY=...
+```
 
-### Dashboard
-- `GET /api/dashboard/velocity`
+Create table and enable RLS:
 
-## Seed data
-Includes a parent container task (`Warehouse Stabilization Program`) with sub-tasks and one MONITOR task.
+```sql
+create table if not exists public.tasks (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  title text not null,
+  description text,
+  notes text,
+  status text not null default 'Not Started',
+  priority text not null default 'Medium',
+  owner text,
+  region text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.tasks enable row level security;
+
+create policy "Users can read own tasks"
+on public.tasks for select
+using (auth.uid() = user_id);
+
+create policy "Users can insert own tasks"
+on public.tasks for insert
+with check (auth.uid() = user_id);
+
+create policy "Users can update own tasks"
+on public.tasks for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "Users can delete own tasks"
+on public.tasks for delete
+using (auth.uid() = user_id);
+```
+
+In Supabase Auth settings, enable email/password sign-in. Create at least one user in Authentication > Users.
+
+## 3) Deploy to Vercel
+
+1. Push repository to GitHub.
+2. Import project into Vercel.
+3. Add environment variables in Vercel project settings:
+   - `NEXT_PUBLIC_SUPABASE_URL`
+   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
+4. Deploy.
+
+Vercel build command: `npm run build`

--- a/README.md
+++ b/README.md
@@ -1,0 +1,66 @@
+# Executive Swipe Decision Accelerator
+
+A lightweight task-management web app focused on executive decision velocity. Tasks are reviewed one at a time using swipe gestures and keyboard shortcuts.
+
+## Stack
+- **Frontend:** React (CDN + JSX via Babel)
+- **Backend:** Node.js + Express
+- **Database:** SQLite
+- **Auth:** Email/password + JWT
+
+## Project structure
+
+- `server.js` - Express server and REST API routes
+- `server/db.js` - SQLite schema + seed helpers
+- `scripts/seed.js` - Manual seed runner
+- `public/index.html` - Frontend shell
+- `public/app.jsx` - Swipe UI, filters, modal editing
+- `public/styles.css` - Mobile-first styles with RAG accents
+
+## Features delivered
+- Swipe review mode with one-task-at-a-time cards
+  - Right: Keep active
+  - Left: Soft-delete (archive)
+  - Down: Move to MONITOR
+  - Up: Open comment/edit modal
+  - Tap: View full details
+- Filtering by horizon, country, theme, parent/sub-task scope
+- Parent container support with progress indicator (`x/y complete`)
+- Comment/edit panel to update responsibility, horizon, notes, RAG
+- Convert any task to parent container and add sub-tasks
+- Basic auth (register/login)
+- Decision velocity dashboard (reviewed today, keep/delete ratio, horizon distribution)
+- Keyboard shortcuts
+  - `→` Keep
+  - `←` Delete
+  - `↑` Comment/Edit
+  - `↓` Move to MONITOR
+
+## Setup
+
+```bash
+npm install
+npm run seed
+npm start
+```
+
+Then open: `http://localhost:3000`
+
+## API overview
+
+### Auth
+- `POST /api/auth/register`
+- `POST /api/auth/login`
+
+### Tasks
+- `GET /api/tasks?horizon=NOW&country=UK&theme=Operations&scope=parents&parent_id=<id>`
+- `GET /api/tasks/:id`
+- `POST /api/tasks`
+- `PATCH /api/tasks/:id`
+- `POST /api/tasks/:id/swipe` with `{ "action": "keep|delete|defer" }`
+
+### Dashboard
+- `GET /api/dashboard/velocity`
+
+## Seed data
+Includes a parent container task (`Warehouse Stabilization Program`) with sub-tasks and one MONITOR task.

--- a/app/components/task-dashboard.tsx
+++ b/app/components/task-dashboard.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+type Task = {
+  id: string;
+  title: string;
+  description: string | null;
+  notes: string | null;
+  status: 'Not Started' | 'In Progress' | 'Completed';
+  priority: 'Low' | 'Medium' | 'High';
+  owner: string | null;
+  region: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
+type TaskInput = Omit<Task, 'id' | 'created_at' | 'updated_at'>;
+
+const defaultTask: TaskInput = {
+  title: '',
+  description: '',
+  notes: '',
+  status: 'Not Started',
+  priority: 'Medium',
+  owner: '',
+  region: '',
+};
+
+export default function TaskDashboard() {
+  const router = useRouter();
+  const [userId, setUserId] = useState<string | null>(null);
+  const [userEmail, setUserEmail] = useState('');
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [newTask, setNewTask] = useState<TaskInput>(defaultTask);
+  const [statusFilter, setStatusFilter] = useState<'All' | Task['status']>('All');
+  const [priorityFilter, setPriorityFilter] = useState<'All' | Task['priority']>('All');
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchTasks = async (currentUserId: string) => {
+    setIsLoading(true);
+    setError(null);
+
+    const { data, error: fetchError } = await supabase
+      .from('tasks')
+      .select('*')
+      .eq('user_id', currentUserId)
+      .order('updated_at', { ascending: false });
+
+    if (fetchError) {
+      setError(fetchError.message);
+      setIsLoading(false);
+      return;
+    }
+
+    setTasks((data ?? []) as Task[]);
+    setIsLoading(false);
+  };
+
+  useEffect(() => {
+    const loadSession = async () => {
+      const {
+        data: { session },
+      } = await supabase.auth.getSession();
+
+      if (!session?.user) {
+        router.replace('/login');
+        return;
+      }
+
+      setUserId(session.user.id);
+      setUserEmail(session.user.email ?? '');
+      fetchTasks(session.user.id);
+    };
+
+    loadSession();
+  }, [router]);
+
+  const visibleTasks = useMemo(
+    () =>
+      tasks.filter((task) => {
+        const statusMatch = statusFilter === 'All' || task.status === statusFilter;
+        const priorityMatch = priorityFilter === 'All' || task.priority === priorityFilter;
+        return statusMatch && priorityMatch;
+      }),
+    [tasks, statusFilter, priorityFilter],
+  );
+
+  const createTask = async () => {
+    if (!userId) return;
+    if (!newTask.title.trim()) {
+      setError('Title is required.');
+      return;
+    }
+
+    setError(null);
+    const now = new Date().toISOString();
+
+    const { error: insertError } = await supabase.from('tasks').insert({
+      ...newTask,
+      user_id: userId,
+      created_at: now,
+      updated_at: now,
+    });
+
+    if (insertError) {
+      setError(insertError.message);
+      return;
+    }
+
+    setNewTask(defaultTask);
+    fetchTasks(userId);
+  };
+
+  const updateTask = async (id: string, patch: Partial<TaskInput>) => {
+    if (!userId) return;
+    const { error: updateError } = await supabase
+      .from('tasks')
+      .update({ ...patch, updated_at: new Date().toISOString() })
+      .eq('id', id)
+      .eq('user_id', userId);
+
+    if (updateError) {
+      setError(updateError.message);
+      return;
+    }
+
+    setTasks((current) =>
+      current.map((task) =>
+        task.id === id
+          ? {
+              ...task,
+              ...patch,
+              updated_at: new Date().toISOString(),
+            }
+          : task,
+      ),
+    );
+  };
+
+  const deleteTask = async (id: string) => {
+    if (!userId) return;
+    const { error: deleteError } = await supabase.from('tasks').delete().eq('id', id).eq('user_id', userId);
+
+    if (deleteError) {
+      setError(deleteError.message);
+      return;
+    }
+
+    setTasks((current) => current.filter((task) => task.id !== id));
+  };
+
+  const signOut = async () => {
+    await supabase.auth.signOut();
+    router.replace('/login');
+  };
+
+  return (
+    <main className="min-h-screen p-4 md:p-8">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <header className="flex flex-col md:flex-row md:items-center justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">Task Dashboard</h1>
+            <p className="text-sm text-slate-400">Signed in as {userEmail}</p>
+          </div>
+          <button onClick={signOut} className="bg-slate-800 hover:bg-slate-700 px-4 py-2 rounded-md text-sm w-fit">
+            Sign Out
+          </button>
+        </header>
+
+        <section className="bg-card border border-slate-800 rounded-xl p-4 space-y-3">
+          <h2 className="font-medium">Create Task</h2>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <input
+              placeholder="Title"
+              value={newTask.title}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, title: e.target.value }))}
+            />
+            <input
+              placeholder="Owner"
+              value={newTask.owner ?? ''}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, owner: e.target.value }))}
+            />
+            <input
+              placeholder="Description"
+              value={newTask.description ?? ''}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, description: e.target.value }))}
+            />
+            <input
+              placeholder="Region"
+              value={newTask.region ?? ''}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, region: e.target.value }))}
+            />
+            <input
+              placeholder="Notes"
+              value={newTask.notes ?? ''}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, notes: e.target.value }))}
+            />
+            <select
+              value={newTask.status}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, status: e.target.value as Task['status'] }))}
+            >
+              <option>Not Started</option>
+              <option>In Progress</option>
+              <option>Completed</option>
+            </select>
+            <select
+              value={newTask.priority}
+              onChange={(e) => setNewTask((prev) => ({ ...prev, priority: e.target.value as Task['priority'] }))}
+            >
+              <option>Low</option>
+              <option>Medium</option>
+              <option>High</option>
+            </select>
+            <button onClick={createTask} className="bg-indigo-600 hover:bg-indigo-500 rounded-md px-4 py-2 font-medium">
+              Add Task
+            </button>
+          </div>
+          {error ? <p className="text-red-400 text-sm">{error}</p> : null}
+        </section>
+
+        <section className="bg-card border border-slate-800 rounded-xl p-4 space-y-4">
+          <div className="flex flex-col md:flex-row gap-3 md:items-center md:justify-between">
+            <h2 className="font-medium">Tasks</h2>
+            <div className="flex gap-2">
+              <select value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as 'All' | Task['status'])}>
+                <option>All</option>
+                <option>Not Started</option>
+                <option>In Progress</option>
+                <option>Completed</option>
+              </select>
+              <select value={priorityFilter} onChange={(e) => setPriorityFilter(e.target.value as 'All' | Task['priority'])}>
+                <option>All</option>
+                <option>Low</option>
+                <option>Medium</option>
+                <option>High</option>
+              </select>
+            </div>
+          </div>
+
+          {isLoading ? <p className="text-sm text-slate-400">Loading tasks...</p> : null}
+
+          {!isLoading && visibleTasks.length === 0 ? (
+            <p className="text-sm text-slate-400">No tasks found for current filters.</p>
+          ) : null}
+
+          <div className="space-y-3">
+            {visibleTasks.map((task) => (
+              <article key={task.id} className="border border-slate-800 rounded-lg p-3 grid grid-cols-1 md:grid-cols-6 gap-2">
+                <input value={task.title} onChange={(e) => updateTask(task.id, { title: e.target.value })} className="md:col-span-2" />
+                <input
+                  value={task.description ?? ''}
+                  onChange={(e) => updateTask(task.id, { description: e.target.value })}
+                  placeholder="Description"
+                  className="md:col-span-2"
+                />
+                <input
+                  value={task.notes ?? ''}
+                  onChange={(e) => updateTask(task.id, { notes: e.target.value })}
+                  placeholder="Notes"
+                  className="md:col-span-2"
+                />
+                <select value={task.status} onChange={(e) => updateTask(task.id, { status: e.target.value as Task['status'] })}>
+                  <option>Not Started</option>
+                  <option>In Progress</option>
+                  <option>Completed</option>
+                </select>
+                <select
+                  value={task.priority}
+                  onChange={(e) => updateTask(task.id, { priority: e.target.value as Task['priority'] })}
+                >
+                  <option>Low</option>
+                  <option>Medium</option>
+                  <option>High</option>
+                </select>
+                <input value={task.owner ?? ''} onChange={(e) => updateTask(task.id, { owner: e.target.value })} placeholder="Owner" />
+                <input value={task.region ?? ''} onChange={(e) => updateTask(task.id, { region: e.target.value })} placeholder="Region" />
+                <button onClick={() => deleteTask(task.id)} className="bg-red-600 hover:bg-red-500 rounded-md px-3 py-2 text-sm">
+                  Delete
+                </button>
+              </article>
+            ))}
+          </div>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,0 +1,5 @@
+import TaskDashboard from '@/app/components/task-dashboard';
+
+export default function DashboardPage() {
+  return <TaskDashboard />;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,0 +1,21 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+body {
+  @apply bg-background text-slate-100 min-h-screen;
+}
+
+input,
+textarea,
+select {
+  @apply bg-slate-900 border border-slate-700 rounded-md px-3 py-2 text-sm text-slate-100 focus:outline-none focus:ring-2 focus:ring-indigo-500;
+}
+
+button {
+  @apply transition-colors;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from 'next';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'Task Manager',
+  description: 'Simple Supabase-powered task manager',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import { FormEvent, useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { supabase } from '@/lib/supabaseClient';
+
+export default function LoginPage() {
+  const router = useRouter();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const checkSession = async () => {
+      const { data } = await supabase.auth.getSession();
+      if (data.session) {
+        router.replace('/dashboard');
+      }
+    };
+
+    checkSession();
+  }, [router]);
+
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsLoading(true);
+    setError(null);
+
+    const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+
+    setIsLoading(false);
+
+    if (signInError) {
+      setError(signInError.message);
+      return;
+    }
+
+    router.replace('/dashboard');
+  };
+
+  return (
+    <main className="min-h-screen flex items-center justify-center px-4">
+      <div className="w-full max-w-md bg-card border border-slate-800 rounded-xl p-6 shadow-lg">
+        <h1 className="text-2xl font-semibold mb-6">Task Manager Login</h1>
+        <form onSubmit={handleLogin} className="space-y-4">
+          <div>
+            <label className="block text-sm text-slate-300 mb-1">Email</label>
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="you@example.com"
+              className="w-full"
+            />
+          </div>
+          <div>
+            <label className="block text-sm text-slate-300 mb-1">Password</label>
+            <input
+              type="password"
+              required
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="••••••••"
+              className="w-full"
+            />
+          </div>
+          {error ? <p className="text-red-400 text-sm">{error}</p> : null}
+          <button
+            type="submit"
+            disabled={isLoading}
+            className="w-full bg-indigo-600 hover:bg-indigo-500 disabled:opacity-60 rounded-md py-2 px-4 font-medium"
+          >
+            {isLoading ? 'Signing in...' : 'Sign In'}
+          </button>
+        </form>
+      </div>
+    </main>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function Home() {
+  redirect('/dashboard');
+}

--- a/lib/supabaseClient.ts
+++ b/lib/supabaseClient.ts
@@ -1,0 +1,6 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL!;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey);

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,0 +1,7 @@
+import type { NextConfig } from 'next';
+
+const nextConfig: NextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "exec-swipe-decision-app",
+  "version": "1.0.0",
+  "description": "Executive decision accelerator task review app",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "seed": "node scripts/seed.js",
+    "check": "node --check server.js && node --check server/db.js"
+  },
+  "dependencies": {
+    "bcryptjs": "^2.4.3",
+    "express": "^4.19.2",
+    "jsonwebtoken": "^9.0.2",
+    "sqlite3": "^5.1.7",
+    "uuid": "^11.0.3"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,18 +1,26 @@
 {
-  "name": "exec-swipe-decision-app",
+  "name": "task-manager-next-supabase",
   "version": "1.0.0",
-  "description": "Executive decision accelerator task review app",
-  "main": "server.js",
+  "private": true,
   "scripts": {
-    "start": "node server.js",
-    "seed": "node scripts/seed.js",
-    "check": "node --check server.js && node --check server/db.js"
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
   },
   "dependencies": {
-    "bcryptjs": "^2.4.3",
-    "express": "^4.19.2",
-    "jsonwebtoken": "^9.0.2",
-    "sqlite3": "^5.1.7",
-    "uuid": "^11.0.3"
+    "@supabase/supabase-js": "^2.57.4",
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  },
+  "devDependencies": {
+    "@types/node": "^22.15.17",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.2",
+    "autoprefixer": "^10.4.21",
+    "postcss": "^8.5.6",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.9.3"
   }
 }

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/public/app.jsx
+++ b/public/app.jsx
@@ -1,0 +1,176 @@
+const { useState, useEffect, useMemo, useRef } = React;
+
+function App() {
+  const [token, setToken] = useState(localStorage.getItem('token') || '');
+  const [form, setForm] = useState({ email: 'exec@example.com', password: 'password123' });
+  const [tasks, setTasks] = useState([]);
+  const [index, setIndex] = useState(0);
+  const [filter, setFilter] = useState({ horizon: 'NOW', country: '', theme: '', scope: 'all', parent_id: '' });
+  const [velocity, setVelocity] = useState(null);
+  const [editingTask, setEditingTask] = useState(null);
+  const cardRef = useRef(null);
+  const startRef = useRef({ x: 0, y: 0 });
+
+  const currentTask = tasks[index];
+
+  const api = async (url, options = {}) => {
+    const headers = { 'Content-Type': 'application/json', ...(options.headers || {}) };
+    if (token) headers.Authorization = `Bearer ${token}`;
+    const response = await fetch(url, { ...options, headers });
+    const body = await response.json();
+    if (!response.ok) throw new Error(body.error || 'Request failed');
+    return body;
+  };
+
+  const loadTasks = async () => {
+    if (!token) return;
+    const params = new URLSearchParams(Object.entries(filter).filter(([, v]) => v));
+    const [taskRes, velocityRes] = await Promise.all([
+      api(`/api/tasks?${params.toString()}`),
+      api('/api/dashboard/velocity')
+    ]);
+    setTasks(taskRes.tasks);
+    setIndex(0);
+    setVelocity(velocityRes);
+  };
+
+  useEffect(() => { loadTasks().catch(alert); }, [token, filter.horizon, filter.country, filter.theme, filter.scope, filter.parent_id]);
+
+  useEffect(() => {
+    const onKey = (e) => {
+      if (!currentTask) return;
+      if (e.key === 'ArrowRight') handleSwipe('keep');
+      if (e.key === 'ArrowLeft') handleSwipe('delete');
+      if (e.key === 'ArrowDown') handleSwipe('defer');
+      if (e.key === 'ArrowUp') setEditingTask(currentTask);
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [currentTask]);
+
+  const handleAuth = async (type) => {
+    const res = await api(`/api/auth/${type}`, { method: 'POST', body: JSON.stringify(form), headers: {} });
+    localStorage.setItem('token', res.token);
+    setToken(res.token);
+  };
+
+  const handleSwipe = async (action) => {
+    await api(`/api/tasks/${currentTask.id}/swipe`, { method: 'POST', body: JSON.stringify({ action }) });
+    await loadTasks();
+  };
+
+  const ragClass = useMemo(() => {
+    if (!currentTask) return '';
+    return currentTask.rag.toLowerCase();
+  }, [currentTask]);
+
+  const onPointerDown = (event) => {
+    startRef.current = { x: event.clientX, y: event.clientY };
+  };
+
+  const onPointerUp = (event) => {
+    const dx = event.clientX - startRef.current.x;
+    const dy = event.clientY - startRef.current.y;
+    if (Math.abs(dx) > Math.abs(dy) && Math.abs(dx) > 80) {
+      if (dx > 0) handleSwipe('keep');
+      else handleSwipe('delete');
+    } else if (Math.abs(dy) > 80) {
+      if (dy > 0) handleSwipe('defer');
+      else setEditingTask(currentTask);
+    }
+  };
+
+  const saveEdit = async () => {
+    await api(`/api/tasks/${editingTask.id}`, { method: 'PATCH', body: JSON.stringify(editingTask) });
+    setEditingTask(null);
+    await loadTasks();
+  };
+
+  const createSubtask = async () => {
+    const title = prompt('Sub-task title');
+    if (!title) return;
+    await api('/api/tasks', {
+      method: 'POST',
+      body: JSON.stringify({
+        title,
+        description: '',
+        country: editingTask.country,
+        theme: editingTask.theme,
+        responsibility: editingTask.responsibility,
+        horizon: 'NOW',
+        status: 'Not Started',
+        rag: 'Amber',
+        parent_id: editingTask.id
+      })
+    });
+    await loadTasks();
+  };
+
+  if (!token) {
+    return <div className="app"><h1>Executive Decision Accelerator</h1><p>Sign in to start high-velocity review.</p>
+      <input placeholder="email" value={form.email} onChange={e => setForm({ ...form, email: e.target.value })} />
+      <input type="password" placeholder="password" value={form.password} onChange={e => setForm({ ...form, password: e.target.value })} />
+      <div className="actions"><button onClick={() => handleAuth('login')}>Login</button><button onClick={() => handleAuth('register')}>Register</button></div>
+    </div>;
+  }
+
+  return <div className="app">
+    <div className="header"><h2>Swipe Review Mode</h2><button onClick={() => { localStorage.removeItem('token'); setToken(''); }}>Logout</button></div>
+
+    {velocity && <div className="metric-grid">
+      <div className="metric"><strong>{velocity.tasksReviewedToday}</strong><div>Reviewed Today</div></div>
+      <div className="metric"><strong>{velocity.keptDeletedRatio}</strong><div>Keep:Delete</div></div>
+      <div className="metric"><strong>{velocity.horizonDistribution.map(h => `${h.horizon}:${h.count}`).join(' | ')}</strong><div>Horizons</div></div>
+    </div>}
+
+    <div className="controls">
+      <select value={filter.horizon} onChange={e => setFilter({ ...filter, horizon: e.target.value })}>
+        <option value="">All Horizons</option><option value="NOW">NOW</option><option value="BUILD">BUILD</option><option value="MONITOR">MONITOR</option>
+      </select>
+      <select value={filter.scope} onChange={e => setFilter({ ...filter, scope: e.target.value })}>
+        <option value="all">All Tasks</option><option value="parents">Parent Containers</option><option value="subtasks">Sub-tasks</option>
+      </select>
+      <input placeholder="Country" value={filter.country} onChange={e => setFilter({ ...filter, country: e.target.value })} />
+      <input placeholder="Theme" value={filter.theme} onChange={e => setFilter({ ...filter, theme: e.target.value })} />
+    </div>
+
+    {currentTask ? <div className={`card ${ragClass}`} ref={cardRef} onPointerDown={onPointerDown} onPointerUp={onPointerUp} onClick={() => alert(currentTask.description)}>
+      <div>
+        <h3>{currentTask.title}</h3>
+        <div className="badges">
+          <span className="badge">{currentTask.country}</span>
+          <span className="badge">{currentTask.horizon}</span>
+          <span className="badge">RAG: {currentTask.rag}</span>
+          <span className="badge">{currentTask.status}</span>
+        </div>
+        <p><strong>Owner:</strong> {currentTask.responsibility}</p>
+        {currentTask.progress && <p><strong>Progress:</strong> {currentTask.progress.completed}/{currentTask.progress.total} complete</p>}
+      </div>
+      <small>Swipe → keep/delete, ↓ defer, ↑ edit, tap for details</small>
+    </div> : <div className="empty">No tasks match the current filters.</div>}
+
+    <div className="actions">
+      <button disabled={!currentTask} onClick={() => handleSwipe('delete')}>Delete ⬅</button>
+      <button disabled={!currentTask} onClick={() => handleSwipe('defer')}>Monitor ⬇</button>
+      <button disabled={!currentTask} onClick={() => setEditingTask(currentTask)}>Comment/Edit ⬆</button>
+      <button disabled={!currentTask} onClick={() => handleSwipe('keep')}>Keep ➡</button>
+    </div>
+
+    {editingTask && <div className="modal"><div className="modal-inner">
+      <h3>Edit Task</h3>
+      <input value={editingTask.responsibility} onChange={e => setEditingTask({ ...editingTask, responsibility: e.target.value })} placeholder="Responsibility" />
+      <select value={editingTask.horizon} onChange={e => setEditingTask({ ...editingTask, horizon: e.target.value })}>
+        <option>NOW</option><option>BUILD</option><option>MONITOR</option>
+      </select>
+      <select value={editingTask.rag} onChange={e => setEditingTask({ ...editingTask, rag: e.target.value })}>
+        <option>Red</option><option>Amber</option><option>Green</option>
+      </select>
+      <textarea rows="4" value={editingTask.notes || ''} onChange={e => setEditingTask({ ...editingTask, notes: e.target.value })} placeholder="Add note" />
+      <button onClick={() => setEditingTask({ ...editingTask, is_container: true })}>Convert to Parent Container</button>
+      <button onClick={createSubtask}>Add Sub-task</button>
+      <div className="actions"><button onClick={() => setEditingTask(null)}>Cancel</button><button onClick={saveEdit}>Save</button></div>
+    </div></div>}
+  </div>;
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Executive Decision Accelerator</title>
+    <link rel="stylesheet" href="/styles.css" />
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="text/babel" src="/app.jsx"></script>
+  </body>
+</html>

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,20 @@
+:root { font-family: Inter, system-ui, sans-serif; }
+body { margin: 0; background: #f5f7fb; color: #101828; }
+.app { max-width: 840px; margin: 0 auto; padding: 16px; }
+.header { display:flex; justify-content:space-between; align-items:center; }
+.controls { display:grid; grid-template-columns: repeat(2,1fr); gap:8px; margin:12px 0; }
+select,input,button,textarea { padding:10px; border-radius:10px; border:1px solid #d0d5dd; font:inherit; }
+button { cursor:pointer; }
+.card { min-height: 360px; border-radius: 20px; padding: 18px; box-shadow: 0 10px 24px rgba(16,24,40,.12); background: white; touch-action: none; display:flex; flex-direction:column; justify-content:space-between; }
+.card.red { background: linear-gradient(160deg, #fff5f5, #fff); }
+.card.amber { background: linear-gradient(160deg, #fff8ed, #fff); }
+.card.green { background: linear-gradient(160deg, #f0fdf4, #fff); }
+.badges { display:flex; gap:8px; flex-wrap:wrap; }
+.badge { padding:5px 10px; border-radius:999px; background:#eaecf0; font-size:12px; }
+.actions { display:grid; grid-template-columns: repeat(4,1fr); gap:8px; margin-top:12px; }
+.empty { background:#fff; border-radius:16px; padding:24px; text-align:center; }
+.modal { position:fixed; inset:0; background:rgba(0,0,0,.36); display:flex; align-items:center; justify-content:center; padding:16px; }
+.modal-inner { background:#fff; border-radius:16px; width:min(600px,100%); padding:16px; display:grid; gap:8px; }
+.metric-grid {display:grid; grid-template-columns: repeat(3,1fr); gap:8px; margin:8px 0; }
+.metric {background:#fff; border-radius:10px; padding:8px; text-align:center; }
+@media (max-width: 640px){ .controls,.actions,.metric-grid{grid-template-columns:1fr;} }

--- a/scripts/seed.js
+++ b/scripts/seed.js
@@ -1,0 +1,8 @@
+const { initDb, seedTasks } = require('../server/db');
+
+(async () => {
+  await initDb();
+  await seedTasks();
+  console.log('Seed complete');
+  process.exit(0);
+})();

--- a/server.js
+++ b/server.js
@@ -1,0 +1,229 @@
+const express = require('express');
+const path = require('path');
+const bcrypt = require('bcryptjs');
+const jwt = require('jsonwebtoken');
+const { run, get, all, initDb, seedTasks, uuidv4 } = require('./server/db');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-me';
+
+app.use(express.json());
+app.use(express.static(path.join(__dirname, 'public')));
+
+function auth(req, res, next) {
+  const header = req.headers.authorization;
+  if (!header || !header.startsWith('Bearer ')) {
+    return res.status(401).json({ error: 'Missing auth token' });
+  }
+
+  try {
+    const token = header.slice(7);
+    req.user = jwt.verify(token, JWT_SECRET);
+    return next();
+  } catch (error) {
+    return res.status(401).json({ error: 'Invalid token' });
+  }
+}
+
+function mapTask(task) {
+  return {
+    ...task,
+    archived: Boolean(task.archived),
+    confirmed: Boolean(task.confirmed),
+    is_container: Boolean(task.is_container)
+  };
+}
+
+app.post('/api/auth/register', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) return res.status(400).json({ error: 'email and password are required' });
+
+  try {
+    const passwordHash = await bcrypt.hash(password, 10);
+    const id = uuidv4();
+    const createdAt = new Date().toISOString();
+    await run('INSERT INTO users (id, email, password_hash, created_at) VALUES (?, ?, ?, ?)', [id, email, passwordHash, createdAt]);
+    const token = jwt.sign({ userId: id, email }, JWT_SECRET, { expiresIn: '7d' });
+    return res.status(201).json({ token });
+  } catch (error) {
+    if (String(error).includes('UNIQUE')) {
+      return res.status(409).json({ error: 'Email already exists' });
+    }
+    return res.status(500).json({ error: 'Could not register' });
+  }
+});
+
+app.post('/api/auth/login', async (req, res) => {
+  const { email, password } = req.body;
+  const user = await get('SELECT * FROM users WHERE email = ?', [email]);
+  if (!user) return res.status(401).json({ error: 'Invalid credentials' });
+  const match = await bcrypt.compare(password, user.password_hash);
+  if (!match) return res.status(401).json({ error: 'Invalid credentials' });
+
+  const token = jwt.sign({ userId: user.id, email: user.email }, JWT_SECRET, { expiresIn: '7d' });
+  return res.json({ token });
+});
+
+app.get('/api/tasks', auth, async (req, res) => {
+  const { horizon, country, theme, parent_id, scope = 'all' } = req.query;
+  const conditions = ['archived = 0'];
+  const params = [];
+
+  if (horizon) {
+    conditions.push('horizon = ?');
+    params.push(horizon);
+  }
+  if (country) {
+    conditions.push('country = ?');
+    params.push(country);
+  }
+  if (theme) {
+    conditions.push('theme = ?');
+    params.push(theme);
+  }
+  if (scope === 'parents') conditions.push('is_container = 1');
+  if (scope === 'subtasks') conditions.push('parent_id IS NOT NULL');
+  if (parent_id) {
+    conditions.push('parent_id = ?');
+    params.push(parent_id);
+  }
+
+  const rows = await all(`SELECT * FROM tasks WHERE ${conditions.join(' AND ')} ORDER BY updated_at DESC`, params);
+  const tasks = [];
+  for (const row of rows) {
+    const task = mapTask(row);
+    if (task.is_container) {
+      const progress = await get(
+        `SELECT COUNT(*) as total, SUM(CASE WHEN status = 'Completed' THEN 1 ELSE 0 END) as completed
+         FROM tasks WHERE parent_id = ? AND archived = 0`,
+        [task.id]
+      );
+      task.progress = {
+        completed: progress?.completed || 0,
+        total: progress?.total || 0
+      };
+    }
+    tasks.push(task);
+  }
+
+  return res.json({ tasks });
+});
+
+app.get('/api/tasks/:id', auth, async (req, res) => {
+  const task = await get('SELECT * FROM tasks WHERE id = ?', [req.params.id]);
+  if (!task) return res.status(404).json({ error: 'Not found' });
+  return res.json({ task: mapTask(task) });
+});
+
+app.post('/api/tasks', auth, async (req, res) => {
+  const payload = req.body;
+  const now = new Date().toISOString();
+  const id = uuidv4();
+  await run(
+    `INSERT INTO tasks (
+      id, title, description, country, theme, responsibility, horizon, status,
+      rag, notes, parent_id, is_container, created_at, updated_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    [
+      id,
+      payload.title,
+      payload.description || '',
+      payload.country,
+      payload.theme,
+      payload.responsibility,
+      payload.horizon || 'NOW',
+      payload.status || 'Not Started',
+      payload.rag || 'Amber',
+      payload.notes || '',
+      payload.parent_id || null,
+      payload.is_container ? 1 : 0,
+      now,
+      now
+    ]
+  );
+  const task = await get('SELECT * FROM tasks WHERE id = ?', [id]);
+  return res.status(201).json({ task: mapTask(task) });
+});
+
+app.patch('/api/tasks/:id', auth, async (req, res) => {
+  const current = await get('SELECT * FROM tasks WHERE id = ?', [req.params.id]);
+  if (!current) return res.status(404).json({ error: 'Not found' });
+
+  const merged = { ...current, ...req.body, updated_at: new Date().toISOString() };
+  await run(
+    `UPDATE tasks SET
+      title = ?, description = ?, country = ?, theme = ?, responsibility = ?, horizon = ?,
+      status = ?, rag = ?, notes = ?, parent_id = ?, is_container = ?, updated_at = ?
+      WHERE id = ?`,
+    [
+      merged.title,
+      merged.description,
+      merged.country,
+      merged.theme,
+      merged.responsibility,
+      merged.horizon,
+      merged.status,
+      merged.rag,
+      merged.notes,
+      merged.parent_id || null,
+      merged.is_container ? 1 : 0,
+      merged.updated_at,
+      req.params.id
+    ]
+  );
+  const task = await get('SELECT * FROM tasks WHERE id = ?', [req.params.id]);
+  return res.json({ task: mapTask(task) });
+});
+
+app.post('/api/tasks/:id/swipe', auth, async (req, res) => {
+  const { action } = req.body;
+  const task = await get('SELECT * FROM tasks WHERE id = ?', [req.params.id]);
+  if (!task) return res.status(404).json({ error: 'Not found' });
+
+  const now = new Date().toISOString();
+  if (action === 'keep') {
+    await run('UPDATE tasks SET confirmed = 1, updated_action = ?, updated_at = ? WHERE id = ?', ['keep', now, req.params.id]);
+  } else if (action === 'delete') {
+    await run('UPDATE tasks SET archived = 1, updated_action = ?, updated_at = ? WHERE id = ?', ['delete', now, req.params.id]);
+  } else if (action === 'defer') {
+    await run("UPDATE tasks SET horizon = 'MONITOR', updated_action = ?, updated_at = ? WHERE id = ?", ['defer', now, req.params.id]);
+  } else {
+    return res.status(400).json({ error: 'Unsupported action' });
+  }
+
+  await run('INSERT INTO reviews (id, task_id, action, reviewed_at) VALUES (?, ?, ?, ?)', [uuidv4(), req.params.id, action, now]);
+  const updated = await get('SELECT * FROM tasks WHERE id = ?', [req.params.id]);
+  return res.json({ task: mapTask(updated) });
+});
+
+app.get('/api/dashboard/velocity', auth, async (_req, res) => {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayIso = todayStart.toISOString();
+
+  const reviewed = await get('SELECT COUNT(*) as count FROM reviews WHERE reviewed_at >= ?', [todayIso]);
+  const kept = await get("SELECT COUNT(*) as count FROM reviews WHERE reviewed_at >= ? AND action = 'keep'", [todayIso]);
+  const deleted = await get("SELECT COUNT(*) as count FROM reviews WHERE reviewed_at >= ? AND action = 'delete'", [todayIso]);
+  const horizonDistribution = await all(
+    `SELECT horizon, COUNT(*) as count FROM tasks WHERE archived = 0 GROUP BY horizon ORDER BY count DESC`
+  );
+
+  return res.json({
+    tasksReviewedToday: reviewed.count,
+    keptDeletedRatio: `${kept.count}:${deleted.count}`,
+    horizonDistribution
+  });
+});
+
+app.get('*', (_req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+(async () => {
+  await initDb();
+  await seedTasks();
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+  });
+})();

--- a/server/db.js
+++ b/server/db.js
@@ -1,0 +1,164 @@
+const path = require('path');
+const sqlite3 = require('sqlite3').verbose();
+const { v4: uuidv4 } = require('uuid');
+
+const dbPath = path.join(__dirname, '..', 'data.sqlite');
+const db = new sqlite3.Database(dbPath);
+
+function run(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function runCallback(err) {
+      if (err) return reject(err);
+      resolve(this);
+    });
+  });
+}
+
+function get(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.get(sql, params, (err, row) => {
+      if (err) return reject(err);
+      resolve(row);
+    });
+  });
+}
+
+function all(sql, params = []) {
+  return new Promise((resolve, reject) => {
+    db.all(sql, params, (err, rows) => {
+      if (err) return reject(err);
+      resolve(rows);
+    });
+  });
+}
+
+async function initDb() {
+  await run(`CREATE TABLE IF NOT EXISTS users (
+    id TEXT PRIMARY KEY,
+    email TEXT UNIQUE NOT NULL,
+    password_hash TEXT NOT NULL,
+    created_at TEXT NOT NULL
+  )`);
+
+  await run(`CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    country TEXT NOT NULL,
+    theme TEXT NOT NULL,
+    responsibility TEXT NOT NULL,
+    horizon TEXT NOT NULL CHECK (horizon IN ('NOW','BUILD','MONITOR')),
+    status TEXT NOT NULL CHECK (status IN ('Not Started','In Progress','Completed')),
+    rag TEXT NOT NULL CHECK (rag IN ('Red','Amber','Green')),
+    notes TEXT DEFAULT '',
+    parent_id TEXT,
+    is_container INTEGER NOT NULL DEFAULT 0,
+    archived INTEGER NOT NULL DEFAULT 0,
+    confirmed INTEGER NOT NULL DEFAULT 0,
+    updated_action TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    FOREIGN KEY(parent_id) REFERENCES tasks(id)
+  )`);
+
+  await run(`CREATE TABLE IF NOT EXISTS reviews (
+    id TEXT PRIMARY KEY,
+    task_id TEXT NOT NULL,
+    action TEXT NOT NULL,
+    reviewed_at TEXT NOT NULL,
+    FOREIGN KEY(task_id) REFERENCES tasks(id)
+  )`);
+}
+
+async function seedTasks() {
+  const existing = await get('SELECT COUNT(*) as count FROM tasks');
+  if (existing && existing.count > 0) return;
+
+  const now = new Date().toISOString();
+  const parentId = uuidv4();
+  const sampleTasks = [
+    {
+      id: parentId,
+      title: 'Warehouse Stabilization Program',
+      description: 'Cross-functional remediation program for Q3 fulfillment disruptions.',
+      country: 'UK',
+      theme: 'Operations',
+      responsibility: 'COO Office',
+      horizon: 'BUILD',
+      status: 'In Progress',
+      rag: 'Amber',
+      notes: 'Parent container for all stabilization tracks.',
+      parent_id: null,
+      is_container: 1
+    },
+    {
+      id: uuidv4(),
+      title: 'Staffing spike response plan',
+      description: 'Align temporary staffing vendors for next 8 weeks.',
+      country: 'UK',
+      theme: 'People',
+      responsibility: 'Head of HR Ops',
+      horizon: 'NOW',
+      status: 'In Progress',
+      rag: 'Red',
+      notes: 'Need board visibility before Friday.',
+      parent_id: parentId,
+      is_container: 0
+    },
+    {
+      id: uuidv4(),
+      title: 'Dock automation pilot',
+      description: 'Pilot conveyor sorting automation in two hubs.',
+      country: 'Germany',
+      theme: 'Automation',
+      responsibility: 'VP Engineering',
+      horizon: 'BUILD',
+      status: 'Not Started',
+      rag: 'Amber',
+      notes: '',
+      parent_id: parentId,
+      is_container: 0
+    },
+    {
+      id: uuidv4(),
+      title: 'Regulatory watch: cross-border VAT adjustments',
+      description: 'Monitor policy changes and prepare compliance position.',
+      country: 'France',
+      theme: 'Compliance',
+      responsibility: 'General Counsel',
+      horizon: 'MONITOR',
+      status: 'In Progress',
+      rag: 'Green',
+      notes: 'No action until legal memo lands.',
+      parent_id: null,
+      is_container: 0
+    }
+  ];
+
+  for (const task of sampleTasks) {
+    await run(
+      `INSERT INTO tasks (
+        id, title, description, country, theme, responsibility, horizon, status, rag,
+        notes, parent_id, is_container, created_at, updated_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        task.id,
+        task.title,
+        task.description,
+        task.country,
+        task.theme,
+        task.responsibility,
+        task.horizon,
+        task.status,
+        task.rag,
+        task.notes,
+        task.parent_id,
+        task.is_container,
+        now,
+        now
+      ]
+    );
+  }
+}
+
+module.exports = { db, run, get, all, initDb, seedTasks, uuidv4 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: ['./app/**/*.{js,ts,jsx,tsx,mdx}', './lib/**/*.{js,ts,jsx,tsx,mdx}'],
+  theme: {
+    extend: {
+      colors: {
+        background: '#0b0f19',
+        card: '#141a2a',
+      },
+    },
+  },
+  plugins: [],
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Motivation

- Provide a lightweight, mobile-first task review app that surfaces one task at a time for executives and drives rapid decisions using swipe mechanics (`Right` keep, `Left` delete, `Down` defer, `Up` edit, `Tap` view). 
- Support parent/child container tasks with progress tracking so reviewers can operate at parent or sub-task level. 
- Ship a minimal full-stack MVP (frontend + backend + seed data) so the app can be run locally for evaluation and iteration. 

### Description

- Implemented an Express API and SQLite persistence with schema and helpers in `server/db.js`, including tables `users`, `tasks`, and `reviews`, and a `seedTasks()` helper to populate sample parent/sub-task data. 
- Added server routes in `server.js` for auth (`/api/auth/register`, `/api/auth/login`), task CRUD (`GET /api/tasks`, `GET /api/tasks/:id`, `POST /api/tasks`, `PATCH /api/tasks/:id`), swipe actions (`POST /api/tasks/:id/swipe` supporting `keep|delete|defer`), and a velocity endpoint (`GET /api/dashboard/velocity`). 
- Built a mobile-first React UI served from `public/` (`index.html`, `app.jsx`, `styles.css`) that implements single-card review, pointer gesture handling (touch + mouse via `onPointerDown`/`onPointerUp`), keyboard shortcuts, filtering (horizon/country/theme/scope), tap-to-view, and an edit/comment modal supporting responsibility/horizon/RAG/notes, convert-to-container and add-subtask flows. 
- Added project metadata and run instructions in `README.md` and lightweight npm manifest in `package.json`, plus `scripts/seed.js` for seeding the DB.

### Testing

- Ran JavaScript syntax checks with `node --check server.js && node --check server/db.js && node --check scripts/seed.js`, which completed successfully. 
- Attempted dependency installation with `npm install`, which failed due to registry access returning `403 Forbidden`, preventing full runtime dependency verification. 
- Attempted an automated UI snapshot via Playwright but the headless run could not load the frontend in this environment (file path / network constraints), so no browser screenshot could be captured here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b2c3e84bc8332812b139c5ef3940b)